### PR TITLE
Update to build and push Docker images for both arm64 and amd64 platforms

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -44,6 +44,12 @@ jobs:
 
       - name: Build with Maven
         run: mvn -Duser.timezone=Europe/Berlin --batch-mode --update-snapshots package
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,29 +38,19 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build with Maven
         run: mvn -Duser.timezone=Europe/Berlin --batch-mode --update-snapshots package
         
-      - name: Build and push Docker image for arm64
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         with:
           file: Dockerfile
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64
-
-      - name: Build and push Docker image for amd64
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          file: Dockerfile
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build with Maven
         run: mvn -Duser.timezone=Europe/Berlin --batch-mode --update-snapshots package
         
-      - name: Build and push Docker image
+      - name: Build and push Docker image for arm64
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           file: Dockerfile
@@ -53,3 +53,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+
+      - name: Build and push Docker image for amd64
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre
 
 ADD target/homedatabroker-1.0.0-SNAPSHOT.jar /app/homedatabroker.jar
 


### PR DESCRIPTION
This pull request updates the Workflow to include instructions for building and pushing Docker images for both the arm64 and amd64 platforms. Previously, only the arm64 platform was supported. With this change, the Docker image can be built and pushed for both platforms, allowing for wider compatibility and deployment options.